### PR TITLE
gridlines-> gridLines typo fix

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,8 +18,8 @@
     "react": "^17.0.1",
     "react-chartjs-2": "^2.11.1",
     "react-dom": "^17.0.1",
-	  "react-scripts": "4.0.0",
-	  "typescript": "4.0.5",
+    "react-scripts": "4.0.0",
+    "typescript": "4.0.5",
     "web-vitals": "^0.2.4"
   },
   "scripts": {
@@ -45,5 +45,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/chart.js": "^2.9.30"
   }
 }

--- a/client/src/components/LineChart.tsx
+++ b/client/src/components/LineChart.tsx
@@ -1,4 +1,4 @@
-import { ChartOptions } from 'chart.js'
+import { ChartLegendOptions, ChartOptions } from 'chart.js'
 import React from 'react'
 import { Line } from 'react-chartjs-2'
 import theme from '../theme'
@@ -12,7 +12,7 @@ type Props = {
 }
 
 const LineChart = ({ xAxisData, yAxisData, title, xLabel, yLabel }: Props) => {
-    const legendOptions = {
+    const legendOptions: ChartLegendOptions = {
         display: false,
     }
 

--- a/client/src/components/LineChart.tsx
+++ b/client/src/components/LineChart.tsx
@@ -1,3 +1,4 @@
+import { ChartOptions } from 'chart.js'
 import React from 'react'
 import { Line } from 'react-chartjs-2'
 import theme from '../theme'
@@ -15,23 +16,24 @@ const LineChart = ({ xAxisData, yAxisData, title, xLabel, yLabel }: Props) => {
         display: false,
     }
 
-    const options = {
+    const options: ChartOptions = {
         title: {
             display: !!title,
             text: title,
         },
         scales: {
-            gridlines: { display: false },
+            gridLines: { display: false },
             yAxes: [
                 {
                     scaleLabel: { display: !!yLabel, labelString: yLabel },
-                    gridlines: { display: false },
+                    gridLines: { display: false },
                 },
             ],
             xAxes: [
                 {
                     scaleLabel: { display: !!xLabel, labelString: xLabel },
                     ticks: { display: true },
+                    gridLines: { display: false },
                 },
             ],
         },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2053,6 +2053,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/chart.js@^2.9.30":
+  version "2.9.30"
+  resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.9.30.tgz#34b99897f4f5ef0f74c8fe4ced70ac52b4d752dd"
+  integrity sha512-EgjxUUZFvf6ls3kW2CwyrnSJhgyKxgwrlp/W5G9wqyPEO9iFatO63zAA7L24YqgMxiDjQ+tG7ODU+2yWH91lPg==
+  dependencies:
+    moment "^2.10.2"
+
 "@types/eslint@^7.2.4":
   version "7.2.5"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.5.tgz#92172ecf490c2fce4b076739693d75f30376d610"


### PR DESCRIPTION
Due to `gridLines` being spelt as `gridlines`, grid lines were not removed from the graph.
I also added `@types/chart.js` to add types and auto-complete to chartjs options/legendOptions.

![firefox_0UVchUPXVi](https://user-images.githubusercontent.com/16054274/107063294-1b13af00-67d2-11eb-9b43-ea76fe71791d.png)
![firefox_yUnVtFcMon](https://user-images.githubusercontent.com/16054274/107063296-1bac4580-67d2-11eb-944f-3f2a99cc9ee7.png)
